### PR TITLE
Nix: don't override Makefile obj{copy,dump} defaults

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -35,16 +35,29 @@ let
   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
   rust_date = "2020-03-06";
   rust_channel = "nightly";
-  rust_targets = [ "thumbv7em-none-eabi" "thumbv7em-none-eabihf" "thumbv6m-none-eabi" "riscv32imac-unknown-none-elf" "riscv32imc-unknown-none-elf"];
+  rust_targets = [
+    "thumbv7em-none-eabi" "thumbv7em-none-eabihf" "thumbv6m-none-eabi"
+    "riscv32imac-unknown-none-elf" "riscv32imc-unknown-none-elf"
+  ];
   rust_build = nixpkgs.rustChannelOfTargets rust_channel rust_date rust_targets;
 in
   with pkgs;
   stdenv.mkDerivation {
     name = "tock-dev";
+
     buildInputs = [
       python3Full
       pythonPackages.tockloader
       rust_build
-      ];
-     LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
+      llvm
+    ];
+
+    LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
+
+    # The defaults "objcopy" and "objdump" are wrong (for x86), use
+    # "llvm-obj{copy,dump}" as defined in the makefile
+    shellHook = ''
+      unset OBJCOPY
+      unset OBJDUMP
+    '';
   }


### PR DESCRIPTION
Fixes the problems stated in https://github.com/tock/tock/pull/1729.

This took me way to long to figure out: nix-shell basically throws you into a development environment with all the dependencies of the derivation. Because we're using the host platform's `mkDerivation`, the `OBJ{COPY,DUMP}` environment variables are set to the host version of the tools.

This adds `llvm` as a dependency and unsets the environment variables before jumping into the shell, so the Makefile default `llvm-objcopy` is used.